### PR TITLE
feat(ui): add Shrine theme & asymmetric layout

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'colors.dart';
 import 'package:flutter/material.dart';
 
 import 'home.dart';
 import 'login.dart';
+
+import 'supplemental/cut_corners_border.dart';
 
 // TODO: Convert ShrineApp to stateful widget (104)
 class ShrineApp extends StatelessWidget {
@@ -35,10 +38,68 @@ class ShrineApp extends StatelessWidget {
         // TODO: Change backLayer field value to CategoryMenuPage (104)
       },
       // TODO: Customize the theme (103)
-      theme: ThemeData.light(useMaterial3: true),
+      theme: _kShrineTheme,
     );
   }
 }
 
 // TODO: Build a Shrine Theme (103)
+final ThemeData _kShrineTheme = _buildShrineTheme();
+
+ThemeData _buildShrineTheme() {
+  final ThemeData base = ThemeData.light();
+  return base.copyWith(
+    colorScheme: base.colorScheme.copyWith(
+      primary: kShrinePurple,
+      secondary: kShrinePurple,
+      error: kShrineErrorRed,
+    ),
+    scaffoldBackgroundColor: kShrineSurfaceWhite,
+    textSelectionTheme: const TextSelectionThemeData(
+      selectionColor: kShrinePurple,
+    ),
+    appBarTheme: const AppBarTheme(
+      foregroundColor: kShrineBrown900,
+      backgroundColor: kShrinePink100,
+    ),
+
+    inputDecorationTheme: const InputDecorationTheme(
+      border: CutCornersBorder(),
+      focusedBorder: CutCornersBorder(
+        borderSide: BorderSide(
+          width: 2.0,
+          color: kShrinePurple,
+        ),
+      ),
+      floatingLabelStyle: TextStyle(
+        color: kShrinePurple,
+      ),
+    ),
+  );
+}
+
 // TODO: Build a Shrine Text Theme (103)
+TextTheme _buildShrineTextTheme(TextTheme base) {
+  return base
+      .copyWith(
+        headlineSmall: base.headlineSmall!.copyWith(
+          fontWeight: FontWeight.w500,
+        ),
+        titleLarge: base.titleLarge!.copyWith(
+          fontSize: 18.0,
+        ),
+        bodySmall: base.bodySmall!.copyWith(
+          fontWeight: FontWeight.w400,
+          fontSize: 14.0,
+        ),
+        bodyLarge: base.bodyLarge!.copyWith(
+          fontWeight: FontWeight.w500,
+          fontSize: 16.0,
+        ),
+      )
+      .apply(
+        fontFamily: 'Rubik',
+        displayColor: kShrineBrown900,
+        bodyColor: kShrineBrown900,
+      );
+}

--- a/lib/colors.dart
+++ b/lib/colors.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+const kShrinePink50 = Color(0xFFFEEAE6);
+const kShrinePink100 = Color(0xFFFEDBD0);
+const kShrinePink300 = Color(0xFFFBB8AC);
+const kShrinePink400 = Color(0xFFEAA4A4);
+
+const kShrineBrown900 = Color(0xFF442B2D);
+
+const kShrineErrorRed = Color(0xFFC5032B);
+
+const kShrineSurfaceWhite = Color(0xFFFFFBFA);
+const kShrineBackgroundWhite = Colors.white;
+
+const kShrinePurple = Color(0xFF5D1049);

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'supplemental/asymmetric_view.dart';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -36,6 +38,7 @@ class HomePage extends StatelessWidget {
       return Card(
         clipBehavior: Clip.antiAlias,
         // TODO: Adjust card heights (103)
+        elevation: 0.0,
         child: Column(
           // TODO: Center items on the card (103)
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -45,7 +48,7 @@ class HomePage extends StatelessWidget {
               child: Image.asset(
                 product.assetName,
                 package: product.assetPackage,
-                fit:BoxFit.fitWidth,
+                fit: BoxFit.fitWidth,
               ),
             ),
             Expanded(
@@ -53,20 +56,24 @@ class HomePage extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 8.0),
                 child: Column(
                   // TODO: Align labels to the bottom and center (103)
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   // TODO: Change innermost Column (103)
                   children: <Widget>[
                     // TODO: Handle overflowing labels (103)
                     Text(
                       product.name,
-                      style: theme.textTheme.titleLarge,
+                      style: theme.textTheme.labelLarge,
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
                       maxLines: 1,
                     ),
-                    const SizedBox(height: 8.0),
+                    const SizedBox(height: 4.0),
                     Text(
                       formatter.format(product.price),
-                      style: theme.textTheme.titleSmall,
+                      style: theme.textTheme.bodySmall,
                     ),
+                    // End new code
                   ],
                 ),
               ),
@@ -83,9 +90,7 @@ class HomePage extends StatelessWidget {
     // TODO: Return an AsymmetricView (104)
     // TODO: Pass Category variable to AsymmetricView (104)
     return Scaffold(
-      
       appBar: AppBar(
-        
         leading: IconButton(
           icon: const Icon(Icons.menu, semanticLabel: 'menu'),
           onPressed: () {
@@ -93,7 +98,6 @@ class HomePage extends StatelessWidget {
           },
         ),
         title: const Text('Acatel'),
-        
         actions: <Widget>[
           IconButton(
             icon: const Icon(
@@ -115,13 +119,14 @@ class HomePage extends StatelessWidget {
           ),
         ],
       ),
-      
-      body: GridView.count(
-        crossAxisCount: 2,
-        padding: const EdgeInsets.all(16.0),
-        childAspectRatio: 8.0 / 9.0,
-        
-        children: _buildGridCards(context),
+      // body: GridView.count(
+      //   crossAxisCount: 2,
+      //   padding: const EdgeInsets.all(16.0),
+      //   childAspectRatio: 8.0 / 9.0,
+      //   children: _buildGridCards(context),
+      // ),
+      body: AsymmetricView(
+        products: ProductsRepository.loadProducts(Category.all),
       ),
       resizeToAvoidBottomInset: false,
     );

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:shrine/colors.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -37,7 +38,10 @@ class _LoginPageState extends State<LoginPage> {
               children: <Widget>[
                 Image.asset('assets/rifky-test.png', width: 64, height: 64),
                 const SizedBox(height: 16.0),
-                const Text('Acatel', style: TextStyle(fontSize: 20.0)),
+                Text(
+                  'ACATEL',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
               ],
             ),
             const SizedBox(height: 120.0),
@@ -46,18 +50,16 @@ class _LoginPageState extends State<LoginPage> {
             TextField(
               controller: _usernameController,
               decoration: const InputDecoration(
-                filled: true,
+                // Removed filled: true
                 labelText: 'Username',
               ),
             ),
-            // spacer
             const SizedBox(height: 12.0),
-            // [PASSWORD]
             TextField(
               controller: _passwordController,
               decoration: const InputDecoration(
-                filled: true,
-                labelText: "Password",
+                // Removed filled: true
+                labelText: 'Password',
               ),
               obscureText: true,
             ),
@@ -71,14 +73,28 @@ class _LoginPageState extends State<LoginPage> {
                     _usernameController.clear();
                     _passwordController.clear();
                   },
+                  style: TextButton.styleFrom(
+                    foregroundColor: kShrineBrown900,
+                    shape: const BeveledRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(7.0)),
+                    ),
+                  ),
                 ),
                 // TODO: Add an elevation to Next (103)
                 // TODO: Add a beveled rectangular border to NEXT (103)
                 ElevatedButton(
-                  child: const Text("Next"),
+                  child: const Text('NEXT'),
                   onPressed: () {
                     Navigator.pop(context);
                   },
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: kShrineBrown900,
+                    backgroundColor: kShrinePink100,
+                    elevation: 8.0,
+                    shape: const BeveledRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(7.0)),
+                    ),
+                  ),
                 ),
               ],
             )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,13 @@ dev_dependencies:
 
 flutter:
   # TODO: Insert Fonts (103)
+  fonts:
+    - family: Rubik
+      fonts:
+        - asset: fonts/Rubik-Regular.ttf
+        - asset: fonts/Rubik-Medium.ttf
+          weight: 500
+          
   uses-material-design: true
   assets:
     - assets/diamond.png


### PR DESCRIPTION
feat(ui): add Shrine theme & asymmetric layout

Legend: {+} add, {-} remove, {~} modify

- lib/app.dart:
  - [+] Add custom Shrine theme, color scheme, text theme builder, and input decoration using CutCornersBorder
  - [+] Import shared colors and supplemental border

- lib/home.dart:
  - [+] Import asymmetric view
  - [~] Replace GridView with AsymmetricView and pass product category
  - [~] Tweak card layout: remove elevation, center labels, adjust spacing, use label/body text styles, and add ellipsis for overflowing names
  - [~] Fix image fit formatting

- lib/login.dart:
  - [+] Import shared colors
  - [~] Update header to use themed headline style and remove filled TextField backgrounds
  - [~] Style actions: add beveled button shapes, colors, and elevation for visual consistency

- pubspec.yaml:
  - [+] Add Rubik font assets

Improves visual consistency and branding by introducing a cohesive theme and typography, modernizes input and button styling, and switches the product layout to a flexible asymmetric view for a more engaging UI.