### PR TITLE
mdc-104-finish

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="shrine"
+        android:label="acatel"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,18 +11,31 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+import 'backdrop.dart';
+import 'category_menu_page.dart';
 import 'colors.dart';
 import 'package:flutter/material.dart';
-
 import 'home.dart';
 import 'login.dart';
-
+import 'model/product.dart';
 import 'supplemental/cut_corners_border.dart';
 
 // TODO: Convert ShrineApp to stateful widget (104)
-class ShrineApp extends StatelessWidget {
+class ShrineApp extends StatefulWidget {
   const ShrineApp({Key? key}) : super(key: key);
+
+  @override
+  State<ShrineApp> createState() => _ShrineAppState();
+}
+
+class _ShrineAppState extends State<ShrineApp> {
+  Category _currentCategory = Category.all;
+
+  void _onCategoryTap(Category category) {
+    setState(() {
+      _currentCategory = category;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,10 +45,19 @@ class ShrineApp extends StatelessWidget {
       routes: {
         '/login': (BuildContext context) => const LoginPage(),
         // TODO: Change to a Backdrop with a HomePage frontLayer (104)
-        '/': (BuildContext context) => const HomePage(),
-        // TODO: Make currentCategory field take _currentCategory (104)
-        // TODO: Pass _currentCategory for frontLayer (104)
-        // TODO: Change backLayer field value to CategoryMenuPage (104)
+        '/': (BuildContext context) => Backdrop(
+              // TODO: Make currentCategory field take _currentCategory (104)
+              currentCategory: _currentCategory,
+              // TODO: Pass _currentCategory for frontLayer (104)
+              frontLayer: HomePage(category: _currentCategory),
+              // TODO: Change backLayer field value to CategoryMenuPage (104)
+              backLayer: CategoryMenuPage(
+                currentCategory: _currentCategory,
+                onCategoryTap: _onCategoryTap,
+              ),
+              frontTitle: const Text('ACATEL'),
+              backTitle: const Text('MENU'),
+            ),
       },
       // TODO: Customize the theme (103)
       theme: _kShrineTheme,
@@ -62,7 +84,6 @@ ThemeData _buildShrineTheme() {
       foregroundColor: kShrineBrown900,
       backgroundColor: kShrinePink100,
     ),
-
     inputDecorationTheme: const InputDecorationTheme(
       border: CutCornersBorder(),
       focusedBorder: CutCornersBorder(

--- a/lib/backdrop.dart
+++ b/lib/backdrop.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+
+import 'login.dart';
+import 'model/product.dart';
+
+// TODO: Add velocity constant (104)
+const double _kFlingVelocity = 2.0;
+
+class Backdrop extends StatefulWidget {
+  final Category currentCategory;
+  final Widget frontLayer;
+  final Widget backLayer;
+  final Widget frontTitle;
+  final Widget backTitle;
+
+  const Backdrop({
+    required this.currentCategory,
+    required this.frontLayer,
+    required this.backLayer,
+    required this.frontTitle,
+    required this.backTitle,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  _BackdropState createState() => _BackdropState();
+}
+
+// TODO: Add _FrontLayer class (104)
+class _FrontLayer extends StatelessWidget {
+  // TODO: Add on-tap callback (104)
+  const _FrontLayer({
+    Key? key,
+    this.onTap,
+    required this.child,
+  }) : super(key: key);
+
+  final VoidCallback? onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 16.0,
+      shape: const BeveledRectangleBorder(
+        borderRadius: BorderRadius.only(topLeft: Radius.circular(46.0)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          // TODO: Add a GestureDetector (104)
+
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onTap,
+            child: Container(
+              height: 40.0,
+              alignment: AlignmentDirectional.centerStart,
+            ),
+          ),
+
+          Expanded(
+            child: child,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// TODO: Add _BackdropTitle class (104)
+
+class _BackdropTitle extends AnimatedWidget {
+  final void Function() onPress;
+  final Widget frontTitle;
+  final Widget backTitle;
+
+  const _BackdropTitle({
+    Key? key,
+    required Animation<double> listenable,
+    required this.onPress,
+    required this.frontTitle,
+    required this.backTitle,
+  })  : _listenable = listenable,
+        super(key: key, listenable: listenable);
+
+  final Animation<double> _listenable;
+
+  @override
+  Widget build(BuildContext context) {
+    final Animation<double> animation = _listenable;
+
+    return DefaultTextStyle(
+      style: Theme.of(context).textTheme.titleLarge!,
+      softWrap: false,
+      overflow: TextOverflow.ellipsis,
+      child: Row(children: <Widget>[
+        // branded icon
+        SizedBox(
+          width: 72.0,
+          child: IconButton(
+            padding: const EdgeInsets.only(right: 8.0),
+            onPressed: this.onPress,
+            icon: Stack(children: <Widget>[
+              Opacity(
+                opacity: animation.value,
+                child: const ImageIcon(AssetImage('assets/slanted_menu.png')),
+              ),
+              FractionalTranslation(
+                translation: Tween<Offset>(
+                  begin: Offset.zero,
+                  end: const Offset(1.0, 0.0),
+                ).evaluate(animation),
+                child: const ImageIcon(AssetImage('assets/rifky-test.png')),
+              )
+            ]),
+          ),
+        ),
+        // Here, we do a custom cross fade between backTitle and frontTitle.
+        // This makes a smooth animation between the two texts.
+        Stack(
+          children: <Widget>[
+            Opacity(
+              opacity: CurvedAnimation(
+                parent: ReverseAnimation(animation),
+                curve: const Interval(0.5, 1.0),
+              ).value,
+              child: FractionalTranslation(
+                translation: Tween<Offset>(
+                  begin: Offset.zero,
+                  end: const Offset(0.5, 0.0),
+                ).evaluate(animation),
+                child: backTitle,
+              ),
+            ),
+            Opacity(
+              opacity: CurvedAnimation(
+                parent: animation,
+                curve: const Interval(0.5, 1.0),
+              ).value,
+              child: FractionalTranslation(
+                translation: Tween<Offset>(
+                  begin: const Offset(-0.25, 0.0),
+                  end: Offset.zero,
+                ).evaluate(animation),
+                child: frontTitle,
+              ),
+            ),
+          ],
+        )
+      ]),
+    );
+  }
+}
+
+// TODO: Add _BackdropState class (104)
+class _BackdropState extends State<Backdrop>
+    with SingleTickerProviderStateMixin {
+  final GlobalKey _backdropKey = GlobalKey(debugLabel: 'Backdrop');
+
+  // TODO: Add AnimationController widget (104)
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 300),
+      value: 1.0,
+      vsync: this,
+    );
+  }
+
+  // TODO: Add override for didUpdateWidget (104)
+
+  @override
+  void didUpdateWidget(Backdrop old) {
+    super.didUpdateWidget(old);
+
+    if (widget.currentCategory != old.currentCategory) {
+      _toggleBackdropLayerVisibility();
+    } else if (!_frontLayerVisible) {
+      _controller.fling(velocity: _kFlingVelocity);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  // TODO: Add functions to get and change front layer visibility (104)
+  bool get _frontLayerVisible {
+    final AnimationStatus status = _controller.status;
+    return status == AnimationStatus.completed ||
+        status == AnimationStatus.forward;
+  }
+
+  void _toggleBackdropLayerVisibility() {
+    _controller.fling(
+        velocity: _frontLayerVisible ? -_kFlingVelocity : _kFlingVelocity);
+  }
+
+  // TODO: Add BuildContext and BoxConstraints parameters to _buildStack (104)
+  Widget _buildStack(BuildContext context, BoxConstraints constraints) {
+    const double layerTitleHeight = 48.0;
+    final Size layerSize = constraints.biggest;
+    final double layerTop = layerSize.height - layerTitleHeight;
+
+    // TODO: Create a RelativeRectTween Animation (104)
+    Animation<RelativeRect> layerAnimation = RelativeRectTween(
+      begin: RelativeRect.fromLTRB(
+          0.0, layerTop, 0.0, layerTop - layerSize.height),
+      end: const RelativeRect.fromLTRB(0.0, 0.0, 0.0, 0.0),
+    ).animate(_controller.view);
+
+    return Stack(
+      key: _backdropKey,
+      children: <Widget>[
+        // TODO: Wrap backLayer in an ExcludeSemantics widget (104)
+        ExcludeSemantics(
+          child: widget.backLayer,
+          excluding: _frontLayerVisible,
+        ),
+        // TODO: Add a PositionedTransition (104)
+        PositionedTransition(
+          rect: layerAnimation,
+          child: _FrontLayer(
+            // TODO: Implement onTap property on _BackdropState (104)
+            onTap: _toggleBackdropLayerVisibility,
+            child: widget.frontLayer,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var appBar = AppBar(
+      elevation: 0.0,
+      titleSpacing: 0.0,
+      // TODO: Replace leading menu icon with IconButton (104)
+      // TODO: Remove leading property (104)
+      // TODO: Create title with _BackdropTitle parameter (104)
+      title: _BackdropTitle(
+        listenable: _controller.view,
+        onPress: _toggleBackdropLayerVisibility,
+        frontTitle: widget.frontTitle,
+        backTitle: widget.backTitle,
+      ),
+      // leading: IconButton(
+      //   icon: const Icon(Icons.menu),
+      //   onPressed: _toggleBackdropLayerVisibility,
+      // ),
+      // title: Text('ACATEL'),
+      actions: <Widget>[
+        // TODO: Add shortcut to login screen from trailing icons (104)
+  
+        IconButton(
+          icon: const Icon(
+            Icons.search,
+            semanticLabel: 'login', // New code
+          ),
+          onPressed: () {
+            // TODO: Add open login (104)
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (BuildContext context) => LoginPage()),
+            );
+          },
+        ),
+        IconButton(
+          icon: const Icon(
+            Icons.tune,
+            semanticLabel: 'login', // New code
+          ),
+          onPressed: () {
+            // TODO: Add open login (104)
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (BuildContext context) => LoginPage()),
+            );
+          },
+        ),
+      ],
+    );
+    return Scaffold(
+        appBar: appBar,
+        // TODO: Return a LayoutBuilder widget (104)
+        body: LayoutBuilder(builder: _buildStack));
+  }
+}

--- a/lib/category_menu_page.dart
+++ b/lib/category_menu_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'colors.dart';
+import 'model/product.dart';
+
+class CategoryMenuPage extends StatelessWidget {
+  final Category currentCategory;
+  final ValueChanged<Category> onCategoryTap;
+  final List<Category> _categories = Category.values;
+
+  const CategoryMenuPage({
+    Key? key,
+    required this.currentCategory,
+    required this.onCategoryTap,
+  }) : super(key: key);
+
+  Widget _buildCategory(Category category, BuildContext context) {
+    final categoryString =
+        category.toString().replaceAll('Category.', '').toUpperCase();
+    final ThemeData theme = Theme.of(context);
+
+    return GestureDetector(
+      onTap: () => onCategoryTap(category),
+      child: category == currentCategory
+          ? Column(
+              children: <Widget>[
+                const SizedBox(height: 16.0),
+                Text(
+                  categoryString,
+                  style: theme.textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 14.0),
+                Container(
+                  width: 70.0,
+                  height: 2.0,
+                  color: kShrinePink400,
+                ),
+              ],
+            )
+          : Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16.0),
+              child: Text(
+                categoryString,
+                style: theme.textTheme.bodyLarge!
+                    .copyWith(color: kShrineBrown900.withAlpha(153)),
+                textAlign: TextAlign.center,
+              ),
+            ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.only(top: 40.0),
+        color: kShrinePink100,
+        child: ListView(
+            children: _categories
+                .map((Category c) => _buildCategory(c, context))
+                .toList()),
+      ),
+    );
+  }
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -12,123 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'supplemental/asymmetric_view.dart';
-
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'model/product.dart';
 import 'model/products_repository.dart';
+import 'supplemental/asymmetric_view.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({Key? key}) : super(key: key);
+  final Category category;
 
-  List<Card> _buildGridCards(BuildContext context) {
-    List<Product> products = ProductsRepository.loadProducts(Category.all);
+  const HomePage({this.category = Category.all, Key? key}) : super(key: key);
 
-    if (products.isEmpty) {
-      return const <Card>[];
-    }
-
-    final ThemeData theme = Theme.of(context);
-    final NumberFormat formatter = NumberFormat.simpleCurrency(
-        locale: Localizations.localeOf(context).toString());
-
-    return products.map((product) {
-      return Card(
-        clipBehavior: Clip.antiAlias,
-        // TODO: Adjust card heights (103)
-        elevation: 0.0,
-        child: Column(
-          // TODO: Center items on the card (103)
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            AspectRatio(
-              aspectRatio: 18 / 11,
-              child: Image.asset(
-                product.assetName,
-                package: product.assetPackage,
-                fit: BoxFit.fitWidth,
-              ),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 8.0),
-                child: Column(
-                  // TODO: Align labels to the bottom and center (103)
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  // TODO: Change innermost Column (103)
-                  children: <Widget>[
-                    // TODO: Handle overflowing labels (103)
-                    Text(
-                      product.name,
-                      style: theme.textTheme.labelLarge,
-                      softWrap: false,
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                    ),
-                    const SizedBox(height: 4.0),
-                    Text(
-                      formatter.format(product.price),
-                      style: theme.textTheme.bodySmall,
-                    ),
-                    // End new code
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-      );
-    }).toList();
-  }
-
-  // TODO: Add a variable for Category (104)
   @override
   Widget build(BuildContext context) {
-    // TODO: Return an AsymmetricView (104)
-    // TODO: Pass Category variable to AsymmetricView (104)
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.menu, semanticLabel: 'menu'),
-          onPressed: () {
-            print('Menu button');
-          },
-        ),
-        title: const Text('Acatel'),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(
-              Icons.search,
-              semanticLabel: 'search',
-            ),
-            onPressed: () {
-              print('Search button');
-            },
-          ),
-          IconButton(
-            icon: const Icon(
-              Icons.tune,
-              semanticLabel: 'filter',
-            ),
-            onPressed: () {
-              print('Filter button');
-            },
-          ),
-        ],
-      ),
-      // body: GridView.count(
-      //   crossAxisCount: 2,
-      //   padding: const EdgeInsets.all(16.0),
-      //   childAspectRatio: 8.0 / 9.0,
-      //   children: _buildGridCards(context),
-      // ),
-      body: AsymmetricView(
-        products: ProductsRepository.loadProducts(Category.all),
-      ),
-      resizeToAvoidBottomInset: false,
-    );
+    return AsymmetricView(products: ProductsRepository.loadProducts(category));
   }
 }

--- a/lib/supplemental/product_columns.dart
+++ b/lib/supplemental/product_columns.dart
@@ -36,12 +36,12 @@ class TwoProductCardColumn extends StatelessWidget {
       double heightOfCards = (constraints.biggest.height - spacerHeight) / 2.0;
       double heightOfImages = heightOfCards - ProductCard.kTextBoxHeight;
       // TODO: Change imageAspectRatio calculation (104)
-      double imageAspectRatio = constraints.biggest.width / heightOfImages;
-
+      double imageAspectRatio = heightOfImages >= 0.0
+          ? constraints.biggest.width / heightOfImages
+          : 49.0 / 33.0;
       // TODO: Replace Column with a ListView (104)
-      return Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
+      return ListView(
+        physics: const ClampingScrollPhysics(),
         children: <Widget>[
           Padding(
             padding: const EdgeInsetsDirectional.only(start: 28.0),
@@ -77,14 +77,15 @@ class OneProductCardColumn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // TODO: Replace Column with a ListView (104)
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.end,
+    return ListView(
+      physics: const ClampingScrollPhysics(),
+      reverse: true,
       children: <Widget>[
-        ProductCard(
-          product: product,
-        ),
         const SizedBox(
           height: 40.0,
+        ),
+        ProductCard(
+          product: product,
         ),
       ],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: shrine
+name: acatel
 description: Learn the basics of using Material Components by building a simple app with core components.
 
 environment:
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ^0.20.2
 
   cupertino_icons: ^1.0.5
   shrine_images: ^2.0.2
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   # TODO: Insert Fonts (103)
@@ -31,6 +31,7 @@ flutter:
     - assets/diamond.png
     - assets/rifky-test.png
     # TODO: Add slanted menu asset (104)
+    - assets/slanted_menu.png
     - packages/shrine_images/0-0.jpg
     - packages/shrine_images/1-0.jpg
     - packages/shrine_images/2-0.jpg


### PR DESCRIPTION
Updates app branding to "acatel" and refactors core navigation to support dynamic category selection via a stateful main widget and backdrop layout.

- AndroidManifest.xml:
  - [~] Change app label to "acatel"
- lib/app.dart:
  - [~] Convert main widget to stateful for category handling
  - [~] Integrate backdrop navigation with menu and category selection
  - [~] Update titles to "ACATEL" and "MENU"
- lib/home.dart:
  - [~] Simplify home page to use AsymmetricView and accept category
  - [~] Remove legacy grid/card UI logic
- lib/supplemental/product_columns.dart:
  - [~] Use ListView instead of Column for product card layouts
  - [~] Add scroll physics and handle reversed list for single product columns
- pubspec.yaml:
  - [~] Change app name to "acatel"
  - [~] Update dependencies: intl and flutter_lints
  - [+] Add slanted_menu.png asset

Improves code organization and prepares for category-based browsing.